### PR TITLE
Replace gpt-3.5-turbo with gpt-3.5-0613

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -25,7 +25,7 @@ OPENAI_API_KEY=your-openai-api-key
 ## PROMPT_SETTINGS_FILE - Specifies which Prompt Settings file to use (defaults to prompt_settings.yaml)
 # PROMPT_SETTINGS_FILE=prompt_settings.yaml
 
-## OPENAI_API_BASE_URL - Custom url for the OpenAI API, useful for connecting to custom backends. No effect if USE_AZURE is true, leave blank to keep the default url 
+## OPENAI_API_BASE_URL - Custom url for the OpenAI API, useful for connecting to custom backends. No effect if USE_AZURE is true, leave blank to keep the default url
 # the following is an example:
 # OPENAI_API_BASE_URL=http://localhost:443/v1
 
@@ -58,11 +58,11 @@ OPENAI_API_KEY=your-openai-api-key
 ### LLM MODELS
 ################################################################################
 
-## SMART_LLM_MODEL - Smart language model (Default: gpt-3.5-turbo)
-# SMART_LLM_MODEL=gpt-3.5-turbo
+## SMART_LLM_MODEL - Smart language model (Default: gpt-3.5-turbo-0613)
+# SMART_LLM_MODEL=gpt-3.5-turbo-0613
 
-## FAST_LLM_MODEL - Fast language model (Default: gpt-3.5-turbo)
-# FAST_LLM_MODEL=gpt-3.5-turbo
+## FAST_LLM_MODEL - Fast language model (Default: gpt-3.5-turbo-0613)
+# FAST_LLM_MODEL=gpt-3.5-turbo-0613
 
 ## EMBEDDING_MODEL - Model to use for creating embeddings
 # EMBEDDING_MODEL=text-embedding-ada-002

--- a/autogpt/config/config.py
+++ b/autogpt/config/config.py
@@ -59,8 +59,8 @@ class Config(metaclass=Singleton):
         self.prompt_settings_file = os.getenv(
             "PROMPT_SETTINGS_FILE", "prompt_settings.yaml"
         )
-        self.fast_llm_model = os.getenv("FAST_LLM_MODEL", "gpt-3.5-turbo")
-        self.smart_llm_model = os.getenv("SMART_LLM_MODEL", "gpt-3.5-turbo")
+        self.fast_llm_model = os.getenv("FAST_LLM_MODEL", "gpt-3.5-turbo-0613")
+        self.smart_llm_model = os.getenv("SMART_LLM_MODEL", "gpt-3.5-turbo-0613")
         self.embedding_model = os.getenv("EMBEDDING_MODEL", "text-embedding-ada-002")
 
         self.browse_spacy_language_model = os.getenv(

--- a/autogpt/configurator.py
+++ b/autogpt/configurator.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from autogpt.config import Config
 
 GPT_4_MODEL = "gpt-4"
-GPT_3_MODEL = "gpt-3.5-turbo"
+GPT_3_MODEL = "gpt-3.5-turbo-0613"
 
 
 def create_config(
@@ -87,7 +87,7 @@ def create_config(
     # Set the default LLM models
     if gpt3only:
         logger.typewriter_log("GPT3.5 Only Mode: ", Fore.GREEN, "ENABLED")
-        # --gpt3only should always use gpt-3.5-turbo, despite user's FAST_LLM_MODEL config
+        # --gpt3only should always use gpt-3.5-turbo-0613, despite user's FAST_LLM_MODEL config
         config.set_fast_llm_model(GPT_3_MODEL)
         config.set_smart_llm_model(GPT_3_MODEL)
 

--- a/autogpt/llm/providers/openai.py
+++ b/autogpt/llm/providers/openai.py
@@ -23,19 +23,13 @@ OPEN_AI_CHAT_MODELS = {
     info.name: info
     for info in [
         ChatModelInfo(
-            name="gpt-3.5-turbo",
-            prompt_token_cost=0.002,
-            completion_token_cost=0.002,
-            max_tokens=4096,
-        ),
-        ChatModelInfo(
-            name="gpt-3.5-turbo-16k-0613",
+            name="gpt-3.5-turbo-16k",
             prompt_token_cost=0.004,
             completion_token_cost=0.003,
             max_tokens=16000,
         ),
         ChatModelInfo(
-            name="gpt-3.5-turbo-0301",
+            name="gpt-3.5-turbo-0613",
             prompt_token_cost=0.002,
             completion_token_cost=0.002,
             max_tokens=4096,

--- a/autogpt/llm/utils/__init__.py
+++ b/autogpt/llm/utils/__init__.py
@@ -170,7 +170,7 @@ def create_chat_completion(
 def check_model(
     model_name: str, model_type: Literal["smart_llm_model", "fast_llm_model"]
 ) -> str:
-    """Check if model is available for use. If not, return gpt-3.5-turbo."""
+    """Check if model is available for use. If not, return gpt-3.5-turbo-0613."""
     api_manager = ApiManager()
     models = api_manager.get_models()
 
@@ -181,6 +181,6 @@ def check_model(
         "WARNING: ",
         Fore.YELLOW,
         f"You do not have access to {model_name}. Setting {model_type} to "
-        f"gpt-3.5-turbo.",
+        f"gpt-3.5-turbo-0613.",
     )
-    return "gpt-3.5-turbo"
+    return "gpt-3.5-turbo-0613"

--- a/autogpt/llm/utils/token_counter.py
+++ b/autogpt/llm/utils/token_counter.py
@@ -10,7 +10,7 @@ from autogpt.logs import logger
 
 
 def count_message_tokens(
-    messages: List[Message], model: str = "gpt-3.5-turbo-0301"
+    messages: List[Message], model: str = "gpt-3.5-turbo-0613"
 ) -> int:
     """
     Returns the number of tokens used by a list of messages.
@@ -19,7 +19,7 @@ def count_message_tokens(
         messages (list): A list of messages, each of which is a dictionary
             containing the role and content of the message.
         model (str): The name of the model to use for tokenization.
-            Defaults to "gpt-3.5-turbo-0301".
+            Defaults to "gpt-3.5-turbo-0613".
 
     Returns:
         int: The number of tokens used by the list of messages.
@@ -29,14 +29,14 @@ def count_message_tokens(
     except KeyError:
         logger.warn("Warning: model not found. Using cl100k_base encoding.")
         encoding = tiktoken.get_encoding("cl100k_base")
-    if model == "gpt-3.5-turbo":
-        # !Note: gpt-3.5-turbo may change over time.
-        # Returning num tokens assuming gpt-3.5-turbo-0301.")
-        return count_message_tokens(messages, model="gpt-3.5-turbo-0301")
+    if model == "gpt-3.5-turbo-0613":
+        # !Note: gpt-3.5-turbo-0613 may change over time.
+        # Returning num tokens assuming gpt-3.5-turbo-0613.")
+        return count_message_tokens(messages, model="gpt-3.5-turbo-0613")
     elif model == "gpt-4":
         # !Note: gpt-4 may change over time. Returning num tokens assuming gpt-4-0314.")
         return count_message_tokens(messages, model="gpt-4-0314")
-    elif model in ["gpt-3.5-turbo-0301", "gpt-3.5-turbo-16k-0613"]:
+    elif model == "gpt-3.5-turbo-0613":
         tokens_per_message = (
             4  # every message follows <|start|>{role/name}\n{content}<|end|>\n
         )
@@ -67,7 +67,7 @@ def count_string_tokens(string: str, model_name: str) -> int:
 
     Args:
         string (str): The text string.
-        model_name (str): The name of the encoding to use. (e.g., "gpt-3.5-turbo")
+        model_name (str): The name of the encoding to use. (e.g., "gpt-3.5-turbo-0613")
 
     Returns:
         int: The number of tokens in the text string.

--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -16,7 +16,7 @@ Configuration is controlled through the `Config` object. You can set configurati
 - `EMBEDDING_MODEL`: LLM Model to use for embedding tasks. Default: text-embedding-ada-002
 - `EXECUTE_LOCAL_COMMANDS`: If shell commands should be executed locally. Default: False
 - `EXIT_KEY`: Exit key accepted to exit. Default: n
-- `FAST_LLM_MODEL`: LLM Model to use for most tasks. Default: gpt-3.5-turbo
+- `FAST_LLM_MODEL`: LLM Model to use for most tasks. Default: gpt-3.5-turbo-0613
 - `GITHUB_API_KEY`: [Github API Key](https://github.com/settings/tokens). Optional.
 - `GITHUB_USERNAME`: GitHub Username. Optional.
 - `GOOGLE_API_KEY`: Google API key. Optional.
@@ -43,7 +43,7 @@ Configuration is controlled through the `Config` object. You can set configurati
 - `SHELL_ALLOWLIST`: List of shell commands that ARE allowed to be executed by Auto-GPT. Only applies if `SHELL_COMMAND_CONTROL` is set to `allowlist`. Default: None
 - `SHELL_COMMAND_CONTROL`: Whether to use `allowlist` or `denylist` to determine what shell commands can be executed (Default: denylist)
 - `SHELL_DENYLIST`: List of shell commands that ARE NOT allowed to be executed by Auto-GPT. Only applies if `SHELL_COMMAND_CONTROL` is set to `denylist`. Default: sudo,su
-- `SMART_LLM_MODEL`: LLM Model to use for "smart" tasks. Default: gpt-3.5-turbo
+- `SMART_LLM_MODEL`: LLM Model to use for "smart" tasks. Default: gpt-3.5-turbo-0613
 - `STREAMELEMENTS_VOICE`: StreamElements voice to use. Default: Brian
 - `TEMPERATURE`: Value of temperature given to OpenAI. Value from 0 to 2. Lower is more deterministic, higher is more random. See https://platform.openai.com/docs/api-reference/completions/create#completions/create-temperature
 - `TEXT_TO_SPEECH_PROVIDER`: Text to Speech Provider. Options are `gtts`, `macos`, `elevenlabs`, and `streamelements`. Default: gtts

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -133,7 +133,7 @@ Get your OpenAI API key from: [https://platform.openai.com/account/api-keys](htt
     make an Azure configuration file:
 
     - Rename `azure.yaml.template` to `azure.yaml` and provide the relevant `azure_api_base`, `azure_api_version` and all the deployment IDs for the relevant models in the `azure_model_map` section:
-        - `fast_llm_model_deployment_id`: your gpt-3.5-turbo or gpt-4 deployment ID
+        - `fast_llm_model_deployment_id`: your gpt-3.5-turbo-0613 or gpt-4 deployment ID
         - `smart_llm_model_deployment_id`: your gpt-4 deployment ID
         - `embedding_model_deployment_id`: your text-embedding-ada-002 v2 deployment ID
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -72,7 +72,7 @@ If you don't have access to GPT-4, this mode allows you to use Auto-GPT!
 ./run.sh --gpt3only
 ```
 
-You can achieve the same by setting `SMART_LLM_MODEL` in `.env` to `gpt-3.5-turbo`.
+You can achieve the same by setting `SMART_LLM_MODEL` in `.env` to `gpt-3.5-turbo-0613`.
 
 ### GPT-4 ONLY Mode
 

--- a/tests/integration/test_provider_openai.py
+++ b/tests/integration/test_provider_openai.py
@@ -19,7 +19,7 @@ def mock_costs():
     with patch.dict(
         COSTS,
         {
-            "gpt-3.5-turbo": {"prompt": 0.002, "completion": 0.002},
+            "gpt-3.5-turbo-0613": {"prompt": 0.002, "completion": 0.002},
             "text-embedding-ada-002": {"prompt": 0.0004, "completion": 0},
         },
         clear=True,
@@ -35,7 +35,7 @@ class TestProviderOpenAI:
             {"role": "system", "content": "You are a helpful assistant."},
             {"role": "user", "content": "Who won the world series in 2020?"},
         ]
-        model = "gpt-3.5-turbo"
+        model = "gpt-3.5-turbo-0613"
         with patch("openai.ChatCompletion.create") as mock_create:
             mock_response = MagicMock()
             del mock_response.error
@@ -51,7 +51,7 @@ class TestProviderOpenAI:
     def test_create_chat_completion_empty_messages():
         """Test if empty messages result in zero tokens and cost."""
         messages = []
-        model = "gpt-3.5-turbo"
+        model = "gpt-3.5-turbo-0613"
 
         with patch("openai.ChatCompletion.create") as mock_create:
             mock_response = MagicMock()

--- a/tests/unit/test_agent_manager.py
+++ b/tests/unit/test_agent_manager.py
@@ -23,7 +23,7 @@ def prompt():
 
 @pytest.fixture
 def model():
-    return "gpt-3.5-turbo"
+    return "gpt-3.5-turbo-0613"
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_api_manager.py
+++ b/tests/unit/test_api_manager.py
@@ -18,7 +18,7 @@ def mock_costs():
     with patch.dict(
         COSTS,
         {
-            "gpt-3.5-turbo": {"prompt": 0.002, "completion": 0.002},
+            "gpt-3.5-turbo-0613": {"prompt": 0.002, "completion": 0.002},
             "text-embedding-ada-002": {"prompt": 0.0004, "completion": 0},
         },
         clear=True,
@@ -29,7 +29,7 @@ def mock_costs():
 class TestApiManager:
     def test_getter_methods(self):
         """Test the getter methods for total tokens, cost, and budget."""
-        api_manager.update_cost(60, 120, "gpt-3.5-turbo")
+        api_manager.update_cost(60, 120, "gpt-3.5-turbo-0613")
         api_manager.set_total_budget(10.0)
         assert api_manager.get_total_prompt_tokens() == 60
         assert api_manager.get_total_completion_tokens() == 120
@@ -49,7 +49,7 @@ class TestApiManager:
         """Test if updating the cost works correctly."""
         prompt_tokens = 50
         completion_tokens = 100
-        model = "gpt-3.5-turbo"
+        model = "gpt-3.5-turbo-0613"
 
         api_manager.update_cost(prompt_tokens, completion_tokens, model)
 
@@ -61,8 +61,8 @@ class TestApiManager:
     def test_get_models():
         """Test if getting models works correctly."""
         with patch("openai.Model.list") as mock_list_models:
-            mock_list_models.return_value = {"data": [{"id": "gpt-3.5-turbo"}]}
+            mock_list_models.return_value = {"data": [{"id": "gpt-3.5-turbo-0613"}]}
             result = api_manager.get_models()
 
-            assert result[0]["id"] == "gpt-3.5-turbo"
-            assert api_manager.models[0]["id"] == "gpt-3.5-turbo"
+            assert result[0]["id"] == "gpt-3.5-turbo-0613"
+            assert api_manager.models[0]["id"] == "gpt-3.5-turbo-0613"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -19,8 +19,8 @@ def test_initial_values(config: Config):
     assert config.debug_mode == False
     assert config.continuous_mode == False
     assert config.speak_mode == False
-    assert config.fast_llm_model == "gpt-3.5-turbo"
-    assert config.smart_llm_model == "gpt-3.5-turbo"
+    assert config.fast_llm_model == "gpt-3.5-turbo-0613"
+    assert config.smart_llm_model == "gpt-3.5-turbo-0613"
 
 
 def test_set_continuous_mode(config: Config):
@@ -58,8 +58,8 @@ def test_set_fast_llm_model(config: Config):
     # Store model name to reset it after the test
     fast_llm_model = config.fast_llm_model
 
-    config.set_fast_llm_model("gpt-3.5-turbo-test")
-    assert config.fast_llm_model == "gpt-3.5-turbo-test"
+    config.set_fast_llm_model("gpt-3.5-turbo-0613-test")
+    assert config.fast_llm_model == "gpt-3.5-turbo-0613-test"
 
     # Reset model name
     config.set_fast_llm_model(fast_llm_model)
@@ -96,7 +96,7 @@ def test_set_debug_mode(config: Config):
 @patch("openai.Model.list")
 def test_smart_and_fast_llm_models_set_to_gpt4(mock_list_models, config: Config):
     """
-    Test if models update to gpt-3.5-turbo if both are set to gpt-4.
+    Test if models update to gpt-3.5-turbo-0613 if both are set to gpt-4.
     """
     fast_llm_model = config.fast_llm_model
     smart_llm_model = config.smart_llm_model
@@ -104,7 +104,7 @@ def test_smart_and_fast_llm_models_set_to_gpt4(mock_list_models, config: Config)
     config.fast_llm_model = "gpt-4"
     config.smart_llm_model = "gpt-4"
 
-    mock_list_models.return_value = {"data": [{"id": "gpt-3.5-turbo"}]}
+    mock_list_models.return_value = {"data": [{"id": "gpt-3.5-turbo-0613"}]}
 
     create_config(
         config=config,
@@ -123,8 +123,8 @@ def test_smart_and_fast_llm_models_set_to_gpt4(mock_list_models, config: Config)
         skip_news=False,
     )
 
-    assert config.fast_llm_model == "gpt-3.5-turbo"
-    assert config.smart_llm_model == "gpt-3.5-turbo"
+    assert config.fast_llm_model == "gpt-3.5-turbo-0613"
+    assert config.smart_llm_model == "gpt-3.5-turbo-0613"
 
     # Reset config
     config.set_fast_llm_model(fast_llm_model)

--- a/tests/unit/test_get_self_feedback.py
+++ b/tests/unit/test_get_self_feedback.py
@@ -51,7 +51,7 @@ def test_get_self_feedback(config: Config, mocker: MockerFixture):
     feedback = Agent.get_self_feedback(
         agent_mock,
         thoughts,
-        "gpt-3.5-turbo",
+        "gpt-3.5-turbo-0613",
     )
 
     # Check if the response is a non-empty string

--- a/tests/unit/test_token_counter.py
+++ b/tests/unit/test_token_counter.py
@@ -39,13 +39,13 @@ def test_count_string_tokens():
     """Test that the string tokens are counted correctly."""
 
     string = "Hello, world!"
-    assert count_string_tokens(string, model_name="gpt-3.5-turbo-0301") == 4
+    assert count_string_tokens(string, model_name="gpt-3.5-turbo-0613") == 4
 
 
 def test_count_string_tokens_empty_input():
     """Test that the string tokens are counted correctly."""
 
-    assert count_string_tokens("", model_name="gpt-3.5-turbo-0301") == 0
+    assert count_string_tokens("", model_name="gpt-3.5-turbo-0613") == 0
 
 
 def test_count_string_tokens_gpt_4():


### PR DESCRIPTION
ONLY GPT-3.5 MODELS WORTH USING: 
- gpt-3.5-turbo-0613 => functions
- gpt-3.5-turbo-16k => doesn't have functions

I don't want us to waste time making gpt-3.5-turbo and gpt-3.5-turbo-0301 backwards compatible => out of the codebase

I don't want to talk about GPT-4 yet, we have to focus on 3.5 for now